### PR TITLE
Removed comma causing seg fault

### DIFF
--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -73,7 +73,7 @@ struct PotreeArguments {
 PotreeArguments parseArguments(int argc, char **argv){
 	Arguments args(argc, argv);
 
-	args.addArgument("source,i,", "input files");
+	args.addArgument("source,i", "input files");
 	args.addArgument("help,h", "prints usage");
 	args.addArgument("generate-page,p", "Generates a ready to use web page with the given name.");
 	args.addArgument("page-template", "directory where the web page template is located.");


### PR DESCRIPTION
- Running PotreeConverter gave me a segmentation fault. This is not an isolated issue. See this issue thread: https://github.com/potree/PotreeConverter/issues/265
- The "source" flag is defined as "source,i,". This allows the source file to be specified using "-i", "--source", or without a flag
- Examples: "./PotreeConverter -i WorldFrameCloud.fb" or "./PotreeConverter WorldFrameCloud.fb"
- I removed the last comma, defining the flag as "source,i". This prevents the seg fault, but removes the ability to specify the source without a flag (i.e. ./PotreeConverter WorldFrameCloud.fb)
- I checked the run-pipeline script and all of the old scripts, and they all use "-i". This means this change won't have any sort of negative impact, but it will prevent segmentation faults