### PR TITLE
PotreeConverter - merge feature/fix-multiple-aabb-calc into develop

### DIFF
--- a/PotreeConverter/include/AABB.h
+++ b/PotreeConverter/include/AABB.h
@@ -21,23 +21,27 @@ public:
 	Vector3<double> min;
 	Vector3<double> max;
 	Vector3<double> size;
+	bool isInitialized;
 
 	AABB(){
 		min = Vector3<double>(std::numeric_limits<float>::max());
 		max = Vector3<double>(-std::numeric_limits<float>::max());
 		size = Vector3<double>(std::numeric_limits<float>::max());
+		isInitialized = false;
 	}
 
 	AABB(const Vector3<double> &p) {
 		min = p;
 		max = p;
 		size = max-min;
+		isInitialized = true;
 	}
 
 	AABB(Vector3<double> min, Vector3<double> max){
 		this->min = min;
 		this->max = max;
 		size = max-min;
+		isInitialized = true;
 	}
 
 	bool isInside(const Vector3<double> &p){
@@ -62,6 +66,7 @@ public:
 		max.z = std::max(max.z, point.z);
 
 		size = max - min;
+		isInitialized = true;
 	}
 
 	void update(const AABB &aabb){
@@ -78,6 +83,7 @@ public:
 		output << "min: " << value.min << endl;
 		output << "max: " << value.max << endl;
 		output << "size: " << value.size << endl;
+		output << "initialized: " << std::boolalpha << value.isInitialized << endl;
 		return output;
 	}
 

--- a/PotreeConverter/src/FlatBufferReader.cpp
+++ b/PotreeConverter/src/FlatBufferReader.cpp
@@ -41,6 +41,11 @@ namespace Potree{
     FlatBufferReader::FlatBufferReader(string path, AABB aabb,  string flatBufferType ) :  pointsIdx(0), pointsLength(0), numSegmentsRead(0), totalNumPoints(0), bboxPointsIdx(0), laneIdx(0), detectionIdx(0), rtkIdx(0) {
 
 
+        std::cout << "========================" << std::endl;
+        std::cout << "FLATBUFFER READER AABB: " << aabb;
+        std::cout << "========================" << std::endl;
+
+
         this->aabb               = aabb;
         this->flatBufferFileType = flatBufferType;
         buffer = new unsigned char[4];
@@ -73,21 +78,23 @@ namespace Potree{
 
         //      Calculate AABB: for every point available in the flatbuffer file override
 
-        pointCount = 0;
-        while(readNextPoint()) {
+        if (!this->aabb.isInitialized) {
+            std::cout << "Provided AABB is uninitialized - computing AABB" << std::endl;
+            pointCount = 0;
+            while(readNextPoint()) {
 
-            const Point p = getPoint();
+                const Point p = getPoint();
 
-            if (pointCount == 0) {
-                this->aabb = AABB(p.position);
+                if (pointCount == 0) {
+                    this->aabb = AABB(p.position);
+                }
+                else {
+                    this->aabb.update(p.position);
+                }
+                pointCount++;
             }
-            else {
-                this->aabb.update(p.position);
-            }
-            pointCount++;
+            std::cout << "Total Number of Points in Cloud: " << totalNumPoints << std::endl;
         }
-
-        std::cout << "Total Number of Points in Cloud: " << totalNumPoints << std::endl;
 
         currentFile = files.begin();
         reader = new ifstream(*currentFile, ios::in | ios::binary);

--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -349,7 +349,7 @@ void PotreeConverter::convert(){
 
 	long long pointsProcessed = 0;
 
-	AABB aabb = calculateAABB();
+	aabb = calculateAABB();
 	cout << "AABB: " << endl << aabb << endl;
 	aabb.makeCubic();
 	cout << "cubic AABB: " << endl << aabb << endl;


### PR DESCRIPTION
PR implements fixes to cache AABB so converter doesn't recompute it unnecessarily. See #20.

