### PR TITLE
Merge maitreyee/aabb into develop

### DIFF
--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -13,6 +13,7 @@
 #include "arguments.hpp"
 #include <experimental/filesystem>
 #include <DataSchemas/Lidar_generated.h>
+#include "functions/VTM_functions.h"
 #include <jmorecfg.h>
 
 
@@ -179,7 +180,26 @@ PotreeArguments parseArguments(int argc, char **argv){
 
 		a.aabbValues = aabbValues;
 	}
-
+	if (args.has("metadata_processing")) {
+		vector<double> aabbValues;
+        auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
+		double adjustmentForLidar = 300;
+		double adjustmentForLidarAlt = 50;
+		double minEastingAdjusted   = vtmMetadata.minEasting + adjustmentForLidar;
+		double minNorthingAdjusted  = vtmMetadata.minNorthing + adjustmentForLidar;
+		double minAltitudeAdjusted = vtmMetadata.minAltitude + adjustmentForLidarAlt;
+		double maxEastingAdjusted   = vtmMetadata.maxEasting - adjustmentForLidar;
+        double maxNorthingAdjusted  = vtmMetadata.maxNorthing - adjustmentForLidar;
+		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude - adjustmentForLidarAlt;
+		aabbValues.push_back(minEastingAdjusted);
+		aabbValues.push_back(minNorthingAdjusted);
+		aabbValues.push_back(minAltitudeAdjusted);
+		aabbValues.push_back(maxEastingAdjusted);
+		aabbValues.push_back(maxNorthingAdjusted);
+		aabbValues.push_back(maxAltitudeAdjusted);
+		a.aabbValues = aabbValues;
+	}
+ 
 	if(args.has("incremental")){
 		a.storeOption = StoreOption::INCREMENTAL;
 	}else if(args.has("overwrite")){

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -179,12 +179,13 @@ PotreeArguments parseArguments(int argc, char **argv){
 			cerr << "AABB requires 6 arguments" << endl;
 			exit(1);
 		}
-		
 		a.aabbValues = aabbValues;
 	}
 
 	if (args.has("metadata_processing")) {
+
 		vector<double> aabbValues;
+
 		auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
 		double minEastingAdjusted   = vtmMetadata.minEasting - PADDING_VTM;
 		double minNorthingAdjusted  = vtmMetadata.minNorthing - PADDING_VTM;
@@ -192,6 +193,7 @@ PotreeArguments parseArguments(int argc, char **argv){
 		double maxEastingAdjusted   = vtmMetadata.maxEasting + PADDING_VTM;
 		double maxNorthingAdjusted  = vtmMetadata.maxNorthing + PADDING_VTM;
 		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude + PADDING_VTM;
+
 		aabbValues.push_back(minEastingAdjusted);
 		aabbValues.push_back(minNorthingAdjusted);
 		aabbValues.push_back(minAltitudeAdjusted);

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -183,14 +183,14 @@ PotreeArguments parseArguments(int argc, char **argv){
 	if (args.has("metadata_processing")) {
 		vector<double> aabbValues;
         auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
-		double adjustmentForLidar = 300;
-		double adjustmentForLidarAlt = 50;
-		double minEastingAdjusted   = vtmMetadata.minEasting - adjustmentForLidar;
-		double minNorthingAdjusted  = vtmMetadata.minNorthing - adjustmentForLidar;
-		double minAltitudeAdjusted = vtmMetadata.minAltitude - adjustmentForLidarAlt;
-		double maxEastingAdjusted   = vtmMetadata.maxEasting + adjustmentForLidar;
-        double maxNorthingAdjusted  = vtmMetadata.maxNorthing + adjustmentForLidar;
-		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude + adjustmentForLidarAlt;
+		double paddingVTM = 300;
+		double paddingAltitude = 100;
+		double minEastingAdjusted   = vtmMetadata.minEasting - paddingVTM;
+		double minNorthingAdjusted  = vtmMetadata.minNorthing - paddingVTM;
+		double minAltitudeAdjusted  = vtmMetadata.minAltitude - paddingAltitude;
+		double maxEastingAdjusted   = vtmMetadata.maxEasting + paddingVTM;
+        double maxNorthingAdjusted  = vtmMetadata.maxNorthing + paddingVTM;
+		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude + paddingAltitude;
 		aabbValues.push_back(minEastingAdjusted);
 		aabbValues.push_back(minNorthingAdjusted);
 		aabbValues.push_back(minAltitudeAdjusted);

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -184,7 +184,7 @@ PotreeArguments parseArguments(int argc, char **argv){
 
 	if (args.has("metadata_processing")) {
 		vector<double> aabbValues;
-        auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
+		auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
 		double minEastingAdjusted   = vtmMetadata.minEasting - PADDING_VTM;
 		double minNorthingAdjusted  = vtmMetadata.minNorthing - PADDING_VTM;
 		double minAltitudeAdjusted  = vtmMetadata.minAltitude - PADDING_VTM;

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -185,12 +185,12 @@ PotreeArguments parseArguments(int argc, char **argv){
         auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
 		double adjustmentForLidar = 300;
 		double adjustmentForLidarAlt = 50;
-		double minEastingAdjusted   = vtmMetadata.minEasting + adjustmentForLidar;
-		double minNorthingAdjusted  = vtmMetadata.minNorthing + adjustmentForLidar;
-		double minAltitudeAdjusted = vtmMetadata.minAltitude + adjustmentForLidarAlt;
-		double maxEastingAdjusted   = vtmMetadata.maxEasting - adjustmentForLidar;
-        double maxNorthingAdjusted  = vtmMetadata.maxNorthing - adjustmentForLidar;
-		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude - adjustmentForLidarAlt;
+		double minEastingAdjusted   = vtmMetadata.minEasting - adjustmentForLidar;
+		double minNorthingAdjusted  = vtmMetadata.minNorthing - adjustmentForLidar;
+		double minAltitudeAdjusted = vtmMetadata.minAltitude - adjustmentForLidarAlt;
+		double maxEastingAdjusted   = vtmMetadata.maxEasting + adjustmentForLidar;
+        double maxNorthingAdjusted  = vtmMetadata.maxNorthing + adjustmentForLidar;
+		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude + adjustmentForLidarAlt;
 		aabbValues.push_back(minEastingAdjusted);
 		aabbValues.push_back(minNorthingAdjusted);
 		aabbValues.push_back(minAltitudeAdjusted);

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -182,6 +182,7 @@ PotreeArguments parseArguments(int argc, char **argv){
 
 		a.aabbValues = aabbValues;
 	}
+	
 	if (args.has("metadata_processing")) {
 		vector<double> aabbValues;
         auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -179,10 +179,9 @@ PotreeArguments parseArguments(int argc, char **argv){
 			cerr << "AABB requires 6 arguments" << endl;
 			exit(1);
 		}
-
 		a.aabbValues = aabbValues;
 	}
-	
+
 	if (args.has("metadata_processing")) {
 		vector<double> aabbValues;
         auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -179,6 +179,7 @@ PotreeArguments parseArguments(int argc, char **argv){
 			cerr << "AABB requires 6 arguments" << endl;
 			exit(1);
 		}
+		
 		a.aabbValues = aabbValues;
 	}
 

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -36,6 +36,8 @@ using Potree::ConversionQuality;
 
 #define MAX_FLOAT std::numeric_limits<float>::max()
 
+constexpr double PADDING_VTM = 300
+
 class SparseGrid;
 
 struct PotreeArguments {
@@ -183,14 +185,12 @@ PotreeArguments parseArguments(int argc, char **argv){
 	if (args.has("metadata_processing")) {
 		vector<double> aabbValues;
         auto vtmMetadata = parseVTMmetadata(a.metadataProcessingFile);
-		double paddingVTM = 300;
-		double paddingAltitude = 100;
-		double minEastingAdjusted   = vtmMetadata.minEasting - paddingVTM;
-		double minNorthingAdjusted  = vtmMetadata.minNorthing - paddingVTM;
-		double minAltitudeAdjusted  = vtmMetadata.minAltitude - paddingAltitude;
-		double maxEastingAdjusted   = vtmMetadata.maxEasting + paddingVTM;
-        double maxNorthingAdjusted  = vtmMetadata.maxNorthing + paddingVTM;
-		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude + paddingAltitude;
+		double minEastingAdjusted   = vtmMetadata.minEasting - PADDING_VTM;
+		double minNorthingAdjusted  = vtmMetadata.minNorthing - PADDING_VTM;
+		double minAltitudeAdjusted  = vtmMetadata.minAltitude - PADDING_VTM;
+		double maxEastingAdjusted   = vtmMetadata.maxEasting + PADDING_VTM;
+		double maxNorthingAdjusted  = vtmMetadata.maxNorthing + PADDING_VTM;
+		double maxAltitudeAdjusted  = vtmMetadata.maxAltitude + PADDING_VTM;
 		aabbValues.push_back(minEastingAdjusted);
 		aabbValues.push_back(minNorthingAdjusted);
 		aabbValues.push_back(minAltitudeAdjusted);


### PR DESCRIPTION
Use easting/northing bounds from VTM calculation (+ appropriate padding) to seed potreeconverter AABB input parameter -- speeds up processing significantly. Will need to determine bounds for z.


