### PR TITLE
James/fix children

### DIFF
--- a/PotreeConverter/include/PotreeWriter.h
+++ b/PotreeConverter/include/PotreeWriter.h
@@ -34,7 +34,7 @@ public:
 	unsigned int numAccepted = 0;
 	PWNode *parent = NULL;
 	vector<PWNode*> children;
-	bool addedSinceLastFlush = true;
+	bool hrcChangedSinceLastFlush = true;
 	bool addCalledSinceLastFlush = false;
 	PotreeWriter *potreeWriter;
 	vector<Point> cache;

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -36,7 +36,7 @@ using Potree::ConversionQuality;
 
 #define MAX_FLOAT std::numeric_limits<float>::max()
 
-constexpr double PADDING_VTM = 300
+constexpr double PADDING_VTM = 300;
 
 class SparseGrid;
 
@@ -202,7 +202,7 @@ PotreeArguments parseArguments(int argc, char **argv){
 		aabbValues.push_back(maxAltitudeAdjusted);
 		a.aabbValues = aabbValues;
 	}
- 
+
 	if(args.has("incremental")){
 		a.storeOption = StoreOption::INCREMENTAL;
 	}else if(args.has("overwrite")){
@@ -352,4 +352,3 @@ int main(int argc, char **argv){
 
 	return 0;
 }
-


### PR DESCRIPTION
Potree Converter now properly marks the number of children a node has. This was accomplished using an upstream issue I found: https://github.com/potree/PotreeConverter/pull/218